### PR TITLE
Add CDN install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Include the CSS files in the `head` tag:
 <link rel="stylesheet" href="dist/basicGrid.min.css">
 ```
 
+or include basicGrid via [jsDelivr CDN](https://www.jsdelivr.com/package/npm/basicgrid):
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/basicgrid@3/dist/basicGrid.min.css">
+```
+
 ## Usage
 
 ### Basics


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/basicgrid) to your readme so it is easier to use. #8 